### PR TITLE
feat: PostgreSQL, Redis, MongoDB 연동 설정 및 테스트 구성

### DIFF
--- a/admin-api/build.gradle.kts
+++ b/admin-api/build.gradle.kts
@@ -21,15 +21,16 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Actuator
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // 헬스체크, 메트릭
 
     // Micrometer
-    implementation("io.micrometer:micrometer-registry-prometheus")
+    implementation("io.micrometer:micrometer-registry-prometheus") // Prometheus 연동
 
     // Sentry
-    implementation("io.sentry:sentry-spring-boot-starter:8.3.0")
-    implementation("io.sentry:sentry-logback:8.3.0")
+    implementation("io.sentry:sentry-spring-boot-starter:8.3.0") // Sentry 연동
+    implementation("io.sentry:sentry-logback:8.3.0") // 로그 수집 연동
 
+    // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/app-api/build.gradle.kts
+++ b/app-api/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("io.sentry.jvm.gradle")
     kotlin("jvm")
     kotlin("plugin.spring")
+    kotlin("plugin.jpa")
 }
 
 dependencies {
@@ -14,6 +15,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
+    // JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // HAL Explorer (JPA 자동 REST 노출)
+    implementation("org.springframework.boot:spring-boot-starter-data-rest")
+    implementation("org.springframework.data:spring-data-rest-hal-explorer")
+
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
@@ -22,14 +30,14 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Actuator
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-actuator") // 헬스체크 및 메트릭
 
     // Micrometer
-    implementation("io.micrometer:micrometer-registry-prometheus")
+    implementation("io.micrometer:micrometer-registry-prometheus") // Prometheus 연동
 
     // Sentry
-    implementation("io.sentry:sentry-spring-boot-starter:8.3.0")
-    implementation("io.sentry:sentry-logback:8.3.0")
+    implementation("io.sentry:sentry-spring-boot-starter:8.3.0") // Sentry 연동
+    implementation("io.sentry:sentry-logback:8.3.0") // Logback 연동
 
     // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/app-api/src/main/kotlin/com/millo/ollim/app/AppApplication.kt
+++ b/app-api/src/main/kotlin/com/millo/ollim/app/AppApplication.kt
@@ -1,9 +1,13 @@
 package com.millo.ollim.app
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = ["com.millo.ollim.core.domain"])
+@EntityScan(basePackages = ["com.millo.ollim.core.domain"])
 class AppApplication
 
 fun main(args: Array<String>) {

--- a/app-api/src/main/kotlin/com/millo/ollim/app/AppApplication.kt
+++ b/app-api/src/main/kotlin/com/millo/ollim/app/AppApplication.kt
@@ -3,11 +3,13 @@ package com.millo.ollim.app
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = ["com.millo.ollim.core.domain"])
 @EntityScan(basePackages = ["com.millo.ollim.core.domain"])
+@ComponentScan(basePackages = ["com.millo.ollim"])
 class AppApplication
 
 fun main(args: Array<String>) {

--- a/app-api/src/main/kotlin/com/millo/ollim/app/controller/RedisController.kt
+++ b/app-api/src/main/kotlin/com/millo/ollim/app/controller/RedisController.kt
@@ -1,0 +1,28 @@
+package com.millo.ollim.app.controller
+
+import com.millo.ollim.infrastructure.redis.RedisService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/redis")
+class RedisController(
+    private val redisService: RedisService
+) {
+    @PostMapping("/save")
+    fun save(@RequestParam key: String,
+             @RequestParam value: String): String {
+        redisService.save(key, value)
+        return "Saved: $key -> $value"
+    }
+
+    @GetMapping("/get")
+    fun get(@RequestParam key: String): String? {
+        return redisService.get(key) ?: "Not found"
+    }
+
+    @DeleteMapping("/delete")
+    fun delete(@RequestParam key: String): String {
+        redisService.delete(key)
+        return "Deleted: $key"
+    }
+}

--- a/app-api/src/main/kotlin/com/millo/ollim/app/controller/TestMongoController.kt
+++ b/app-api/src/main/kotlin/com/millo/ollim/app/controller/TestMongoController.kt
@@ -1,0 +1,32 @@
+package com.millo.ollim.app.controller
+
+import com.millo.ollim.core.domain.test.TestDocument
+import com.millo.ollim.infrastructure.mongo.TestMongoService
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/mongo")
+class TestMongoController(
+    private val testMongoService: TestMongoService
+) {
+
+    @PostMapping
+    fun createTest(): TestDocument {
+        return testMongoService.saveTestData()
+    }
+
+    @GetMapping
+    fun readTest(): List<TestDocument> {
+        return testMongoService.getAllTestData()
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteTest(@PathVariable id: String): TestDocument {
+        return testMongoService.deleteTestData(id)
+    }
+}

--- a/app-api/src/main/kotlin/com/millo/ollim/app/controller/TestRedisController.kt
+++ b/app-api/src/main/kotlin/com/millo/ollim/app/controller/TestRedisController.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/redis")
-class RedisController(
+class TestRedisController(
     private val redisService: RedisService
 ) {
     @PostMapping("/save")

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -26,12 +26,12 @@ spring:
     rest:
       base-path: /api
 
-  database:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
-      database: 0
+database:
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+    database: ${REDIS_DATABASE}
 
 springdoc:
   api-docs:

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -1,10 +1,37 @@
 spring:
   application:
     name: app-api
+
   profiles:
     active: private
+
   config:
     import: optional:file:../.env[.properties]
+
+  datasource:
+    url: ${POSTGRES_URL}
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    rest:
+      base-path: /api
+
+  database:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      database: 0
 
 springdoc:
   api-docs:

--- a/app-api/src/main/resources/application.yml
+++ b/app-api/src/main/resources/application.yml
@@ -26,6 +26,14 @@ spring:
     rest:
       base-path: /api
 
+    mongodb:
+      host: ${MONGO_HOST}
+      port: ${MONGO_PORT}
+      username: ${MONGO_USERNAME}
+      password: ${MONGO_PASSWORD}
+      database: ${MONGO_DATABASE}
+      authentication-database: ${AUTHENTICATION_DATABASE}
+
 database:
   redis:
     host: ${REDIS_HOST}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,16 +5,25 @@ plugins {
 }
 
 dependencies {
-//    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
+    // Spring Data JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
-    // Kotlin
+    // Spring Data REST (HAL 자동 노출 및 Repository 어노테이션 사용 시 필요)
+    implementation("org.springframework.boot:spring-boot-starter-data-rest")
+
+    // PostgreSQL
+    runtimeOnly("org.postgresql:postgresql")
+
+    // Kotlin 리플렉션
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // Kotlin 전용 Jackson 직렬화
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Jasypt
-    implementation ("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
+    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
 
+    // 테스트
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 }
 
 dependencies {
-    // Spring Data JPA
+
+    // JPA
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     // Spring Data REST (HAL 자동 노출 및 Repository 어노테이션 사용 시 필요)
@@ -13,6 +14,9 @@ dependencies {
 
     // PostgreSQL
     runtimeOnly("org.postgresql:postgresql")
+
+    // Mongo
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
     // Kotlin 리플렉션
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/core/src/main/kotlin/com/millo/ollim/core/domain/dummy/DummyEntity.kt
+++ b/core/src/main/kotlin/com/millo/ollim/core/domain/dummy/DummyEntity.kt
@@ -1,0 +1,17 @@
+package com.millo.ollim.core.domain.dummy
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "dummy")
+class DummyEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val name: String
+)

--- a/core/src/main/kotlin/com/millo/ollim/core/domain/dummy/DummyRepository.kt
+++ b/core/src/main/kotlin/com/millo/ollim/core/domain/dummy/DummyRepository.kt
@@ -1,0 +1,8 @@
+package com.millo.ollim.core.domain.dummy
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.rest.core.annotation.RepositoryRestResource
+
+@RepositoryRestResource(path = "dummy")
+interface DummyRepository: JpaRepository<DummyEntity, Long> {
+}

--- a/core/src/main/kotlin/com/millo/ollim/core/domain/test/TestDocument.kt
+++ b/core/src/main/kotlin/com/millo/ollim/core/domain/test/TestDocument.kt
@@ -1,0 +1,9 @@
+package com.millo.ollim.core.domain.test
+
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "test_documents")
+data class TestDocument(
+    val id: String? = null,
+    val message: String
+)

--- a/core/src/main/kotlin/com/millo/ollim/core/domain/test/TestDocumentRepository.kt
+++ b/core/src/main/kotlin/com/millo/ollim/core/domain/test/TestDocumentRepository.kt
@@ -1,0 +1,5 @@
+package com.millo.ollim.core.domain.test
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface TestDocumentRepository: MongoRepository<TestDocument, String>

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -1,29 +1,33 @@
 plugins {
-	kotlin("jvm")
-	kotlin("plugin.spring")
-	kotlin("plugin.jpa")
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    kotlin("plugin.jpa")
 }
 
 dependencies {
-	implementation(project(":core"))
+    implementation(project(":core"))
 
-	implementation("org.springframework.boot:spring-boot-starter-web")
+    // spring-web
+    implementation("org.springframework.boot:spring-boot-starter-web")
 
-//	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-//	implementation("org.springframework.boot:spring-boot-starter-data-redis")
-//	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
-//	runtimeOnly("org.postgresql:postgresql")
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
-	// Kotlin
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+     // Mongo
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
-	// Tests
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    // Kotlin 리플렉션
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+     // Kotlin 전용 Jackson 직렬화
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+    // 테스트
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.named<Jar>("jar") {
-	enabled = true
+    enabled = true
 }

--- a/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/config/MongoConfig.kt
+++ b/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/config/MongoConfig.kt
@@ -1,0 +1,31 @@
+package com.millo.ollim.infrastructure.config
+
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
+
+@Configuration
+@EnableMongoRepositories(basePackages = ["com.millo.ollim"])
+class MongoConfig(
+    @Value("\${spring.data.mongodb.host}") private val host: String,
+    @Value("\${spring.data.mongodb.port}") private val port: Int,
+    @Value("\${spring.data.mongodb.username}") private val username: String,
+    @Value("\${spring.data.mongodb.password}") private val password: String,
+    @Value("\${spring.data.mongodb.database}") private val database: String
+) {
+
+    @Bean
+    fun mongoClient(): MongoClient {
+        val connectionString = "mongodb://$username:$password@$host:$port/$database"
+        return MongoClients.create(connectionString)
+    }
+
+    @Bean
+    fun mongoTemplate(): MongoTemplate {
+        return MongoTemplate(mongoClient(), database)
+    }
+}

--- a/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/config/RedisConfig.kt
+++ b/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/config/RedisConfig.kt
@@ -1,0 +1,36 @@
+package com.millo.ollim.infrastructure.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+
+    @Bean
+    fun redisConnectionFactory(
+        @Value("\${database.redis.host}") host: String,
+        @Value("\${database.redis.port}") port: Int,
+        @Value("\${database.redis.password:}") password: String,
+        @Value("\${database.redis.database:0}") database: Int
+    ): LettuceConnectionFactory {
+        val config = RedisStandaloneConfiguration(host, port).apply {
+            this.database = database
+            if (password.isNotBlank()) this.setPassword(password)
+        }
+        return LettuceConnectionFactory(config)
+    }
+
+    @Bean
+    fun redisTemplate(redisConnectionFactory: LettuceConnectionFactory): RedisTemplate<String, String> {
+        return RedisTemplate<String, String>().apply {
+            setConnectionFactory(redisConnectionFactory)
+            keySerializer = StringRedisSerializer()
+            valueSerializer = StringRedisSerializer()
+        }
+    }
+}

--- a/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/mongo/TestMongoService.kt
+++ b/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/mongo/TestMongoService.kt
@@ -1,0 +1,31 @@
+package com.millo.ollim.infrastructure.mongo
+
+import com.millo.ollim.core.domain.test.TestDocument
+import com.millo.ollim.core.domain.test.TestDocumentRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TestMongoService(
+    private val testDocumentRepository: TestDocumentRepository
+) {
+    @Transactional
+    fun saveTestData(): TestDocument {
+        val document = TestDocument(message = "hello(Mongo)")
+        return testDocumentRepository.save(document)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllTestData(): List<TestDocument> {
+        return testDocumentRepository.findAll()
+    }
+
+    @Transactional
+    fun deleteTestData(id: String): TestDocument {
+        val document = testDocumentRepository.findById(id)
+            .orElseThrow { NoSuchElementException("해당 ID의 문서를 찾을 수 없습니다: $id") }
+
+        testDocumentRepository.deleteById(id)
+        return document
+    }
+}

--- a/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/redis/RedisService.kt
+++ b/infrastructure/src/main/kotlin/com/millo/ollim/infrastructure/redis/RedisService.kt
@@ -1,0 +1,22 @@
+package com.millo.ollim.infrastructure.redis
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RedisService(
+    private val redisTemplate: RedisTemplate<String, String>
+) {
+
+    fun save(key: String, value: String) {
+        redisTemplate.opsForValue().set(key, value)
+    }
+
+    fun get(key: String): String? {
+        return redisTemplate.opsForValue().get(key)
+    }
+
+    fun delete(key: String) {
+        redisTemplate.delete(key)
+    }
+}

--- a/infrastructure/src/main/resources/application.properties
+++ b/infrastructure/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=infrastructure

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: infrastructure


### PR DESCRIPTION
> 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. <br>어떻게보다 무엇을 왜 수정했는지 설명해주세요.

### 🔗 관련 이슈
<!-- 연관된 이슈 번호를 적어주세요 -->
#1

### ✨ 어떤 변경 사항이 있나요?
<!-- 실제 변경된 핵심 내용을 bullet로 작성해주세요 -->
- PostgreSQL 연동 설정 완료 (Spring Data JPA + HikariCP, Hal Explore 사용(/api))
- Redis 설정 (RedisTemplate 및 LettuceConnectionFactory 구성)
- MongoDB 연동 설정 (MongoTemplate, MongoRepository 사용)
- 각 설정을 infrastructure/config에 분리하여 모듈화 적용
- .env 및 application.yml 연동으로 설정값 외부 주입
- 테스트용 도메인/Document 및 Repository/Service/Controller 구성 (TestDocument)
- /mongo/test, /redis/test 등 연동 확인용 API 구현


### ⚠️ 참고사항
- MongoDB는 core.domain 패키지 내 Repository를 인식하기 위해 @EnableMongoRepositories 설정 필요
- Redis, Mongo 테스트는 단순 연동 확인용이며, 추후 실제 기능 구현 시 확장 필요
- 각 모듈의 역할에 맞춰 core는 인터페이스, infrastructure는 설정 및 구현 클래스를 분리함
- 테스트 시 MongoDB 사용자/비밀번호, PostgreSQL 접속정보 등 .env 파일 내 설정 필요